### PR TITLE
Bug: JsonReader failed to read integers as single and double

### DIFF
--- a/src/FsPickler.Json/JsonReader.fs
+++ b/src/FsPickler.Json/JsonReader.fs
@@ -158,6 +158,7 @@ type internal JsonPickleReader (jsonReader : JsonReader, omitHeader, useCustomSe
             let value =
                 match jsonReader.TokenType with
                 | JsonToken.Float -> jsonReader.ValueAs<double> () |> single
+                | JsonToken.Integer -> jsonReader.ValueAs<int64> () |> single
                 | JsonToken.String -> Single.Parse(jsonReader.ValueAs<string>(), CultureInfo.InvariantCulture)
                 | _ -> raise <| new FormatException("not a float.")
 
@@ -172,6 +173,7 @@ type internal JsonPickleReader (jsonReader : JsonReader, omitHeader, useCustomSe
             let value =
                 match jsonReader.TokenType with
                 | JsonToken.Float -> jsonReader.ValueAs<double> ()
+                | JsonToken.Integer -> jsonReader.ValueAs<int64> () |> double
                 | JsonToken.String -> Double.Parse(jsonReader.ValueAs<string>(), CultureInfo.InvariantCulture)
                 | _ -> raise <| new FormatException("not a float.")
 

--- a/tests/FsPickler.Tests/SerializerTests.fs
+++ b/tests/FsPickler.Tests/SerializerTests.fs
@@ -1107,3 +1107,20 @@ type ``FsPickler Serializer Tests`` (format : string) as self =
             raise <| new AssertionException(msg)
         else
             printfn "Failed Serializations: %d out of %d." failedResults results.Length
+
+module TestsByExample =
+    [<Test>]
+    let ``Unpickle a single from a Json integer should pass``() =
+        let jser = JsonSerializer(false, true)
+        let json = "10";
+        let current = jser.UnPickleOfString(json, Combinators.Pickler.single)
+        let expected = 10.0f
+        Assert.That(current, Is.EqualTo expected)
+
+    [<Test>]
+    let ``Unpickle a double from a Json integer should pass``() =
+        let jser = JsonSerializer(false, true)
+        let json = "10";
+        let current = jser.UnPickleOfString(json, Combinators.Pickler.double)
+        let expected = 10.0
+        Assert.That(current, Is.EqualTo expected)


### PR DESCRIPTION
I detected this case where an integer failed to be recognized as a double. Tried to fix it in this PR. I dont know if the same case would apply to XML or binary formatters.