### PR TITLE
Use FSharp.Compiler.Tools instead of the system compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ paket-files/
 docs/output/
 temp/
 /.vs/FsPickler/v15/sqlite3/storage.ide
+/.idea/.idea.FsPickler

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 image: Visual Studio 2017
 configuration: Release
+install:
+ - .paket\paket.bootstrapper.exe
+ - .paket\paket.exe restore
 test:
   assemblies:
     - FsPickler.Tests.dll

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -32,4 +32,5 @@ group Build
   nuget FAKE
   nuget FSharp.Core 4.2.1
   nuget FSharp.Formatting ~> 2.14.4
+  nuget FSharp.Compiler.Tools
   github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -14,6 +14,7 @@ NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.63.2)
     FSharp.Compiler.Service (2.0.0.6)
+    FSharp.Compiler.Tools (4.1.23)
     FSharp.Core (4.2.1)
     FSharp.Formatting (2.14.4)
       FSharp.Compiler.Service (2.0.0.6)

--- a/src/FsPickler.Json/FsPickler.Json.fsproj
+++ b/src/FsPickler.Json/FsPickler.Json.fsproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props" Condition="Exists('..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props')" Label="Paket" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -68,18 +69,6 @@
     <OutputPath>..\..\bin\NoEmit\</OutputPath>
     <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/src/FsPickler.Json/paket.references
+++ b/src/FsPickler.Json/paket.references
@@ -1,2 +1,4 @@
 FSharp.Core copy_local:false
 Newtonsoft.Json
+group Build    
+  FSharp.Compiler.Tools

--- a/src/FsPickler/FsPickler.fsproj
+++ b/src/FsPickler/FsPickler.fsproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props" Condition="Exists('..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props')" Label="Paket" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -134,18 +135,6 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="..\..\.paket\paket.targets" />
   <Choose>

--- a/src/FsPickler/paket.references
+++ b/src/FsPickler/paket.references
@@ -1,2 +1,4 @@
 ﻿FSharp.Core copy_local:false
 File: TypeShape.fs TypeShape
+group Build    
+  FSharp.Compiler.Tools

--- a/tests/FsPickler.PerfTests/FsPickler.PerfTests.fsproj
+++ b/tests/FsPickler.PerfTests/FsPickler.PerfTests.fsproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props" Condition="Exists('..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props')" Label="Paket" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -63,18 +64,6 @@
     <DocumentationFile>..\..\bin\FsPickler.PerfTests.XML</DocumentationFile>
     <OutputPath>bin\Release-NET40\</OutputPath>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>

--- a/tests/FsPickler.PerfTests/paket.references
+++ b/tests/FsPickler.PerfTests/paket.references
@@ -7,3 +7,5 @@ group Test
   PerfUtil
   PerfUtil.NUnit
   protobuf-net
+group Build    
+  FSharp.Compiler.Tools

--- a/tests/FsPickler.Tests/FsPickler.Tests.fsproj
+++ b/tests/FsPickler.Tests/FsPickler.Tests.fsproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props" Condition="Exists('..\..\packages\build\FSharp.Compiler.Tools\build\FSharp.Compiler.Tools.props')" Label="Paket" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -76,18 +77,6 @@
     <Prefer32Bit>true</Prefer32Bit>
     <OutputPath>..\..\bin\net35\</OutputPath>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ItemGroup>

--- a/tests/FsPickler.Tests/paket.references
+++ b/tests/FsPickler.Tests/paket.references
@@ -5,3 +5,5 @@ group Test
   FsUnit
   NUnit
   System.ValueTuple
+group Build    
+  FSharp.Compiler.Tools


### PR DESCRIPTION
Trying to build on windows fails in VS, Rider and fake:

![image](https://user-images.githubusercontent.com/4236651/30521887-9393e330-9bc7-11e7-983f-e3b4cf4dfdcd.png)

I assume that is because this change by don is not yet included in these two IDEs (and fake uses the VS compiler): https://github.com/Microsoft/visualfsharp/pull/3283

Even unrelated to this timing issue, I am a big fan of not relying on system state.

What do you think?

It would be possible to do the same for the C# compiler with "Microsoft.Net.Compilers", so you could use C#7 features, and even people with only VS2013 could still compile the projects.