### PR TITLE
Add a test for union cases with named fields

### DIFF
--- a/tests/FsPickler.Tests/SerializerTests.fs
+++ b/tests/FsPickler.Tests/SerializerTests.fs
@@ -742,6 +742,8 @@ type ``FsPickler Serializer Tests`` (format : string) as self =
     //  Custom types
     //
 
+    [<Test ; Category("Custom types")>]
+    member __.``6. Custom: Union with named data`` () = NamedDUData "" |> testEquals
 
     [<Test ; Category("Custom types")>] 
     member __.``6. Custom: simple class`` () = testEquals <| SimpleClass(42, "fortyTwo")

--- a/tests/FsPickler.Tests/TestTypes.fs
+++ b/tests/FsPickler.Tests/TestTypes.fs
@@ -25,6 +25,8 @@ module TestTypes =
         | Zero
         | Succ of Peano
 
+    type NamedDUData = NamedDUData of AA: string
+
     type GenericDU<'T> = GValue of 'T
 
     [<Struct>]


### PR DESCRIPTION
The test fails when building with Visual Studio 2017 15.5.2 (F# 4.1).
The cause appears to be in TypeShape, see https://github.com/eiriktsarpalis/TypeShape/issues/14