### PR TITLE
Fixing pickling directory info

### DIFF
--- a/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
+++ b/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
@@ -64,7 +64,6 @@ type PicklerGenerator =
         | :? TypeShape<Assembly> -> ReflectionPicklers.CreateAssemblyPickler resolver :> _
         | :? TypeShape<MemberInfo> -> ReflectionPicklers.CreateMemberInfoPickler ArrayPickler.Create resolver :> _
         | :? TypeShape<System.DBNull> -> new DBNullPickler() :> _
-
         | PicklerFactory factory ->
             let pickler = factory resolver
             if pickler.Type <> shape.Type then

--- a/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
+++ b/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
@@ -42,6 +42,7 @@ type PicklerGenerator =
             if pickler.Type <> shape.Type then
                 raise <| PicklerGenerationException(shape.Type, "unexpected pickler type from custom pickler generator.")
             pickler
+
         | _ when isUnsupportedType shape.Type -> raise <| NonSerializableTypeException shape.Type
         | Shape.Bool -> new BooleanPickler() :> _
         | Shape.Byte -> new BytePickler() :> _

--- a/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
+++ b/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
@@ -70,6 +70,9 @@ type PicklerGenerator =
                 raise <| PicklerGenerationException(shape.Type, "unexpected pickler type from custom pickler generator.")
             pickler
 
+        // The unsupported check is now after the pickler factory case due to the fact that the DirectoryInfo
+        // type has 'IsMarshalByRef' set if .NET framework is used. This allows someone to specify
+        // a custom pickler that will serialize a DirectoryInfo.
         | _ when isUnsupportedType shape.Type -> raise <| NonSerializableTypeException shape.Type
 
         | Shape.Nullable s ->

--- a/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
+++ b/src/FsPickler/PicklerGeneration/PicklerGenerator.fs
@@ -37,13 +37,6 @@ type PicklerGenerator =
         let (|PicklerFactory|_|) (shape : TypeShape) = registry.TryGetPicklerFactory shape.Type
 
         match shape with
-        | PicklerFactory factory ->
-            let pickler = factory resolver
-            if pickler.Type <> shape.Type then
-                raise <| PicklerGenerationException(shape.Type, "unexpected pickler type from custom pickler generator.")
-            pickler
-
-        | _ when isUnsupportedType shape.Type -> raise <| NonSerializableTypeException shape.Type
         | Shape.Bool -> new BooleanPickler() :> _
         | Shape.Byte -> new BytePickler() :> _
         | Shape.SByte -> new SBytePickler() :> _
@@ -71,6 +64,14 @@ type PicklerGenerator =
         | :? TypeShape<Assembly> -> ReflectionPicklers.CreateAssemblyPickler resolver :> _
         | :? TypeShape<MemberInfo> -> ReflectionPicklers.CreateMemberInfoPickler ArrayPickler.Create resolver :> _
         | :? TypeShape<System.DBNull> -> new DBNullPickler() :> _
+
+        | PicklerFactory factory ->
+            let pickler = factory resolver
+            if pickler.Type <> shape.Type then
+                raise <| PicklerGenerationException(shape.Type, "unexpected pickler type from custom pickler generator.")
+            pickler
+
+        | _ when isUnsupportedType shape.Type -> raise <| NonSerializableTypeException shape.Type
 
         | Shape.Nullable s ->
             s.Accept {

--- a/tests/FsPickler.Tests/SerializerTests.fs
+++ b/tests/FsPickler.Tests/SerializerTests.fs
@@ -163,7 +163,7 @@ type SerializationTests (fixture : ISerializerFixture) =
         let registry = new CustomPicklerRegistry ()
         registry.RegisterFactory makeDirectoryInfoPickler
         let cache = PicklerCache.FromCustomPicklerRegistry registry
-        let ser = FsPickler.CreateBinarySerializer (picklerResolver = cache)
+        let ser = FsPickler.CreateXmlSerializer (picklerResolver = cache)
         di
         |> ser.PickleToString
         |> ser.UnPickleOfString<DirectoryInfo>

--- a/tests/FsPickler.Tests/SerializerTests.fs
+++ b/tests/FsPickler.Tests/SerializerTests.fs
@@ -146,6 +146,29 @@ type SerializationTests (fixture : ISerializerFixture) =
     [<Test; Category("Bytes")>]
     member __.``Primitive: byte []`` () = testEquals (null : byte []) ; Check.QuickThrowOnFail<byte []> testEquals
 
+    [<Test; Category("DirectoryInfo")>]
+    member __.``DirectoryInfo`` () =
+        let makeDirectoryInfoPickler (resolver : IPicklerResolver) =
+            let stringPickler = resolver.Resolve<string> ()
+
+            let writer (w : WriteState) (di : DirectoryInfo) =
+                stringPickler.Write w "Directory" di.FullName
+
+            let reader (r : ReadState) =
+                stringPickler.Read r "Directory" |> DirectoryInfo
+
+            Pickler.FromPrimitives (reader, writer)
+
+        let di = DirectoryInfo "testDirectory"
+        let registry = new CustomPicklerRegistry ()
+        registry.RegisterFactory makeDirectoryInfoPickler
+        let cache = PicklerCache.FromCustomPicklerRegistry registry
+        let ser = FsPickler.CreateBinarySerializer (picklerResolver = cache)
+        di
+        |> ser.PickleToString
+        |> ser.UnPickleOfString<DirectoryInfo>
+        |> should equal di
+
     //
     //  Reflection types
     //


### PR DESCRIPTION
This fixes our issue regarding the pickling of a directory info. I've chosen to move the custom pickler up, rather than changing where the isUnsupportedType check happens. The rationale behind this is that if a user provides a custom pickler that is probably what should be used.